### PR TITLE
chore: add vitest/global in tsconfig

### DIFF
--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,5 +1,3 @@
-// App.spec.jsx
-import { describe, it, afterEach, expect } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // toBeIntheDocument 등 not a function뜨면 jest-dom import하면 사용 가능함...

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "esModuleInterop": true, // JS의 ESM 방식과 node,js의 Commonjs 방식을 호환
+    "esModuleInterop": true, // JS의 ESM 방식과 node.js의 Commonjs 방식을 호환
     "types": ["vitest/globals"]
   },
   "include": ["src", "setupTests.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "esModuleInterop": true // JS의 ESM 방식과 node,js의 Commonjs 방식을 호환
+    "esModuleInterop": true, // JS의 ESM 방식과 node,js의 Commonjs 방식을 호환
+    "types": ["vitest/globals"]
   },
   "include": ["src", "setupTests.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
# Why
test 작성 시, vitest import가 필요없게 하기위해 추가하였습니다.
# How
tsconfig에 "types": ["vitest/globals"] 추가
# Result
src/App.spec.tsx 에서 지워진것 확인가능
# Prize
귀찮음 감소
# Reference
[vitest공식문서](https://vitest.dev/config/#globals)