### PR TITLE
feat: add react grid layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-grid-layout": "^1.4.4",
         "styled-components": "^6.1.8",
         "styled-reset": "^4.5.2"
       },
@@ -23,6 +24,7 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
+        "@types/react-grid-layout": "^1.3.5",
         "@types/styled-components": "^5.1.34",
         "@typescript-eslint/eslint-plugin": "^7.6.0",
         "@typescript-eslint/parser": "^7.6.0",
@@ -2420,6 +2422,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-grid-layout": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.5.tgz",
+      "integrity": "sha512-WH/po1gcEcoR6y857yAnPGug+ZhkF4PaTUxgAbwfeSH/QOgVSakKHBXoPGad/sEznmkiaK3pqHk+etdWisoeBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -3494,6 +3505,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -4707,6 +4726,11 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -6651,7 +6675,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7111,7 +7134,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7121,8 +7143,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -7198,6 +7219,44 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.4.4.tgz",
+      "integrity": "sha512-7+Lg8E8O8HfOH5FrY80GCIR1SHTn2QnAYKh27/5spoz+OHhMmEhU/14gIkRzJOtympDPaXcVRX/nT1FjmeOUmQ==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.5",
+        "react-resizable": "^3.0.5",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -7211,6 +7270,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.5.tgz",
+      "integrity": "sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3"
       }
     },
     "node_modules/react-router": {
@@ -7360,6 +7431,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-grid-layout": "^1.4.4",
     "styled-components": "^6.1.8",
     "styled-reset": "^4.5.2"
   },
@@ -30,6 +31,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@types/react-grid-layout": "^1.3.5",
     "@types/styled-components": "^5.1.34",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",

--- a/src/app/providers/App.tsx
+++ b/src/app/providers/App.tsx
@@ -3,6 +3,9 @@ import GlobalStyles from '../styles/GlobalStyles';
 import { theme } from '../styles/Theme';
 import BrowserRouter from './RouterProvider';
 
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
+
 const App = () => {
   return (
     <>

--- a/src/shared/hooks/useOutsideClick.ts
+++ b/src/shared/hooks/useOutsideClick.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const useOutSideClick = (
+  ref: React.RefObject<HTMLObjectElement>,
+  callback: () => void
+) => {
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    window.addEventListener('mousedown', handleClick);
+
+    return () => window.removeEventListener('mousedown', handleClick);
+  }, [ref, callback]);
+};
+
+export default useOutSideClick;

--- a/src/shared/ui/Modal/index.tsx
+++ b/src/shared/ui/Modal/index.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+import { useRef } from 'react';
+import useOutSideClick from '@shared/hooks/useOutsideClick';
+import ModalPortal from '../ModalPortal';
+
+type ModalProps = {
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+const Modal = ({ onClose, children }: ModalProps) => {
+  const modalRef = useRef(null);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  useOutSideClick(modalRef, handleClose);
+
+  return (
+    <ModalPortal>
+      <Overlay className="notDraggable">
+        <ModalWrap ref={modalRef}>{children}</ModalWrap>
+      </Overlay>
+    </ModalPortal>
+  );
+};
+
+export default Modal;
+
+const Overlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.2);
+  z-index: 9999;
+`;
+
+const ModalWrap = styled.div`
+  max-width: 600px;
+  height: fit-content;
+  border-radius: 15px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;

--- a/src/widgets/widgetLayer/ui/WidgetLayer.tsx
+++ b/src/widgets/widgetLayer/ui/WidgetLayer.tsx
@@ -1,12 +1,89 @@
 import styled from 'styled-components';
 import SiteLinkContainer from './../../widgetList/siteLink/ui/SiteLinkContainer';
+import { useCallback, useState } from 'react';
+
+import { Responsive, WidthProvider } from 'react-grid-layout';
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+type LayoutItem = {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+const WIDGET_KEYS = {
+  siteLink: 'siteLink',
+};
+
+const ROW_HEIGHT = 100;
 
 const WidgetLayer = () => {
   // 각 위젯 별 show 여부 상태로 관리 필요, 우선 SiteLink로 예시
+  const [layoutState, setLayoutState] = useState<{
+    breakpoints: string;
+    layouts: { [key: string]: LayoutItem[] };
+  }>({
+    breakpoints: 'lg',
+    layouts: {},
+  });
+
   const visibleStatus = { SiteLink: true };
+
+  const onBreakPointChange = (breakpoint: string) => {
+    setLayoutState(state => ({
+      ...state,
+      breakpoints: breakpoint,
+    }));
+  };
+
+  const handleLayoutChange = (
+    _: ReactGridLayout.Layout[],
+    layouts: ReactGridLayout.Layouts
+  ) => {
+    setLayoutState(state => ({
+      ...state,
+      layouts: layouts,
+    }));
+  };
+
+  const getHeight = useCallback(
+    (key: string) => {
+      return (
+        ROW_HEIGHT *
+        layoutState.layouts[layoutState.breakpoints]?.filter(
+          ({ i }) => i === key
+        )[0].h
+      );
+    },
+    [layoutState.breakpoints, layoutState.layouts]
+  );
+
   return (
     <WidgetContainer>
-      {visibleStatus.SiteLink && <SiteLinkContainer />}
+      <ResponsiveGridLayout
+        style={{ height: '100%' }}
+        className="layout"
+        layouts={layoutState.layouts}
+        breakpoints={{ lg: 1200, md: 996, sm: 768 }}
+        cols={{ lg: 12, md: 10, sm: 6 }}
+        rowHeight={ROW_HEIGHT}
+        draggableCancel=".notDraggable"
+        verticalCompact={false}
+        allowOverlap
+        onBreakpointChange={onBreakPointChange}
+        onLayoutChange={handleLayoutChange}>
+        {/* FIXME: 임시로 item A 및 B 추가. 향후 위젯 추가시 삭제 요망*/}
+        <div key="a">Item A</div>
+        <div key="b">Item B</div>
+        <div key={WIDGET_KEYS.siteLink}>
+          {visibleStatus.SiteLink && (
+            <SiteLinkContainer height={getHeight(WIDGET_KEYS.siteLink)} />
+          )}
+        </div>
+      </ResponsiveGridLayout>
     </WidgetContainer>
   );
 };

--- a/src/widgets/widgetLayer/ui/WidgetLayer.tsx
+++ b/src/widgets/widgetLayer/ui/WidgetLayer.tsx
@@ -71,7 +71,7 @@ const WidgetLayer = () => {
         cols={{ lg: 12, md: 10, sm: 6 }}
         rowHeight={ROW_HEIGHT}
         draggableCancel=".notDraggable"
-        verticalCompact={false}
+        compactType="horizontal"
         allowOverlap
         onBreakpointChange={onBreakPointChange}
         onLayoutChange={handleLayoutChange}>

--- a/src/widgets/widgetList/layout/SettingLayout.tsx
+++ b/src/widgets/widgetList/layout/SettingLayout.tsx
@@ -10,31 +10,16 @@ const SettingLayout: React.FC<SettingLayoutProps> = ({
   handleClose,
 }) => {
   return (
-    <Wrapper>
-      <Container>
-        <Header>
-          <XButton onClick={handleClose} />
-        </Header>
-        <Content>{children}</Content>
-      </Container>
-    </Wrapper>
+    <Container>
+      <Header>
+        <XButton onClick={handleClose} />
+      </Header>
+      <Content>{children}</Content>
+    </Container>
   );
 };
 
 export default SettingLayout;
-
-// 화면 전체 크기 덮는 wrap
-const Wrapper = styled.div`
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: rgba(0, 0, 0, 0.15);
-  position: absolute;
-  top: 0;
-  left: 0;
-`;
 
 // 자식 크기에 맞춰져야 하므로, Container에 따로 width, heignt 지정하면 안된다.
 const Container = styled.div`

--- a/src/widgets/widgetList/layout/WidgetLayout.tsx
+++ b/src/widgets/widgetList/layout/WidgetLayout.tsx
@@ -25,7 +25,8 @@ const WidgetLayout: React.FC<WidgetLayoutProps> = ({ children, height }) => {
 
   useEffect(() => {
     if (wrapperRef.current) {
-      setIsHeaderTop(wrapperRef.current.offsetTop >= 35);
+      const top = wrapperRef.current.getBoundingClientRect().top;
+      setIsHeaderTop(top >= 35);
     }
   }, [height]); // height가 변경될 때마다 다시 계산
 

--- a/src/widgets/widgetList/layout/WidgetLayout.tsx
+++ b/src/widgets/widgetList/layout/WidgetLayout.tsx
@@ -7,20 +7,14 @@ import SettingIcon from '@assets/icon/settingIcon.svg?react'; // svg import 시 
 import CloseIcon from '@assets/icon/closeIcon.svg?react'; // svg import 시 ?react 필수
 
 type WidgetWrapType = {
-  width: string;
   height: string;
 };
 type WidgetLayoutProps = WidgetWrapType & {
   children: React.ReactNode[]; // 자식 노드를 2개 가지며, 첫번째 노드는 위젯이 들어가며, 두번째 노드는 환경설정 내용이 됩니다.
-  width: string;
   height: string;
 };
 
-const WidgetLayout: React.FC<WidgetLayoutProps> = ({
-  children,
-  width,
-  height,
-}) => {
+const WidgetLayout: React.FC<WidgetLayoutProps> = ({ children, height }) => {
   const [showSetting, setShowSetting] = useState<boolean>(false);
   const toggleSetting = () => {
     setShowSetting(prev => !prev);
@@ -36,9 +30,9 @@ const WidgetLayout: React.FC<WidgetLayoutProps> = ({
   }, [height]); // height가 변경될 때마다 다시 계산
 
   return (
-    <Wrapper ref={wrapperRef} width={width} height={height}>
+    <Wrapper ref={wrapperRef} height={height}>
       <Content>{children[0]}</Content>
-      <Header top={isHeaderTop ? '-35px' : height}>
+      <Header top={isHeaderTop ? '-35px' : height} className="notDraggable">
         <SettingButton onClick={toggleSetting} />
         <CloseButton />
       </Header>
@@ -57,7 +51,6 @@ export default WidgetLayout;
 
 // Content에서 Header 을 다음 형제 선택자로 선택하기 위해 column-reverse 사용
 const Wrapper = styled.div<WidgetWrapType>`
-  width: ${props => props.width};
   height: ${props => props.height};
   //   background-color: lightGray;
   display: flex;

--- a/src/widgets/widgetList/layout/WidgetLayout.tsx
+++ b/src/widgets/widgetList/layout/WidgetLayout.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
-import ModalPortal from '@shared/ui/ModalPortal';
 import SettingLayout from './SettingLayout';
 import React, { useEffect, useRef, useState } from 'react';
 
 import SettingIcon from '@assets/icon/settingIcon.svg?react'; // svg import 시 ?react 필수
 import CloseIcon from '@assets/icon/closeIcon.svg?react'; // svg import 시 ?react 필수
+import Modal from '@shared/ui/Modal';
 
 type WidgetWrapType = {
   height: string;
@@ -37,11 +37,11 @@ const WidgetLayout: React.FC<WidgetLayoutProps> = ({ children, height }) => {
         <CloseButton />
       </Header>
       {showSetting && (
-        <ModalPortal>
+        <Modal onClose={toggleSetting}>
           <SettingLayout handleClose={toggleSetting}>
             {children[1]}
           </SettingLayout>
-        </ModalPortal>
+        </Modal>
       )}
     </Wrapper>
   );

--- a/src/widgets/widgetList/siteLink/ui/SiteLinkContainer.tsx
+++ b/src/widgets/widgetList/siteLink/ui/SiteLinkContainer.tsx
@@ -5,18 +5,20 @@ import styled from 'styled-components';
 import data from '../api/data';
 import { useState } from 'react';
 
-const SiteLinkContainer = () => {
+type SiteLinkContainerProps = {
+  height: number;
+};
+
+const SiteLinkContainer = ({ height }: SiteLinkContainerProps) => {
   const [currentTabSeq, setCurrentTabSeq] = useState<number>(0);
   const _data = data;
   const handleSelectTab = (tabSeq: number) => {
     setCurrentTabSeq(tabSeq);
   };
-  const width = 600;
-  const height = 300;
   return (
-    <WidgetLayout width={`${width}px`} height={`${height}px`}>
+    <WidgetLayout height={`${height}px`}>
       <TabWrapper>
-        <TabMenu>
+        <TabMenu className="notDraggable">
           {_data.map(item => (
             <li
               key={item.tabSeq}

--- a/src/widgets/widgetList/siteLink/ui/SiteLinkItem.tsx
+++ b/src/widgets/widgetList/siteLink/ui/SiteLinkItem.tsx
@@ -8,7 +8,7 @@ type SiteLinkItemProps = {
 
 const SiteLinkItem: React.FC<SiteLinkItemProps> = ({ linkInfo }) => {
   return (
-    <LinkWrapper>
+    <LinkWrapper className="notDraggable">
       <a href={linkInfo.linkURL}></a>
       <LinkFavicon>
         <img src={icon} />

--- a/src/widgets/widgetList/siteLink/ui/SiteLinkTabContent.tsx
+++ b/src/widgets/widgetList/siteLink/ui/SiteLinkTabContent.tsx
@@ -21,7 +21,8 @@ const SiteLinkTabContent: React.FC<SiteLinkTabContentProps> = ({
             linkSeq: 100,
             linkTitle: '추가하기',
             linkURL: '',
-          }}></SiteLinkItem>
+          }}
+        />
       )}
     </Content>
   );


### PR DESCRIPTION
# Why
react-grid-layout 추가하여 위젯 배치 가능하게 함
# How
작업사항
1. react-grid-layout 설치 및 적용
2. 설정에 있떤 wrap 부분 modal로 이동
3. 모달 외부 클릭 시 닫아지게 변경

위젯 추가 시 작업해야할 사항
1. key값 추가
4. height에 getHeight(해당key) 값 추가
5. 마우스 이벤트가 있는곳의 `className`에 `notDraggable`추가 필요 (그렇지 않으면 클릭이벤트와 드래그이벤트가 동시에 이뤄집니다.)

추후 추가작업사항
1. widget마다 minWidth 각각 설정
2. 위치 및 크기 값 스토리지 저장

특이사항
1. 현재 위젯이동을 자유롭게하기위해서 겹치기 까지 가능합니다.
2. 만약 위젯이동을 자유롭게하면서 겹치지 않게하면 이동하는 위젯때문에 남아있던 위젯이동이 조금 부자연스럽습니다. [여기 참고](https://react-grid-layout.github.io/react-grid-layout/examples/11-no-vertical-compact.html) 부탁드립니다.

# Result
https://github.com/PomPom-Home/PomPomHome/assets/79738187/8aaa1d72-0059-4268-bfb7-49e8a2b54355

# Prize

# Reference
[react-grid-layout](https://github.com/react-grid-layout/react-grid-layout?tab=readme-ov-file#providing-grid-width)
